### PR TITLE
fix: improve app name validation for heroku

### DIFF
--- a/heroku-worker-dyno/main.tf
+++ b/heroku-worker-dyno/main.tf
@@ -31,9 +31,8 @@ provider "coder" {
 }
 
 resource "heroku_app" "workspace" {
-  count = data.coder_workspace.me.start_count
-  name  = join("-", [data.coder_workspace.me.owner, substr(data.coder_workspace.me.id, 0, 8)])
-  # name   = "coder-${data.coder_workspace.me.owner}-${data.coder_workspace.me.name}-${data.coder_workspace.me.id}"
+  count  = data.coder_workspace.me.start_count
+  name   = lower(join("-", [substr(data.coder_workspace.me.owner, 0, 20), substr(data.coder_workspace.me.id, 0, 8)]))
   region = data.coder_parameter.region.value
   stack  = "container"
   config_vars = {


### PR DESCRIPTION
1. usernames in Coder can go up to 32 characters, while Heroku requires the full app name to be 30
2. usernames in Coder can be capitalized, while Heroku app names cannot be (at least for the first letter)