### PR TITLE
add restart policy  `restart  = "unless-stopped"` to all docker templates

### DIFF
--- a/deeplearning-nvidia/main.tf
+++ b/deeplearning-nvidia/main.tf
@@ -312,6 +312,7 @@ resource "docker_container" "workspace" {
   dns      = ["1.1.1.1"]
   command  = ["sh", "-c", replace(coder_agent.main.init_script, "127.0.0.1", "host.docker.internal")]
   env      = ["CODER_AGENT_TOKEN=${coder_agent.main.token}"]
+  restart  = "unless-stopped"
 
   devices {
     host_path = "/dev/nvidia0"

--- a/deeplearning/main.tf
+++ b/deeplearning/main.tf
@@ -298,6 +298,7 @@ resource "docker_container" "workspace" {
   dns      = ["1.1.1.1"]
   command  = ["sh", "-c", replace(coder_agent.main.init_script, "127.0.0.1", "host.docker.internal")]
   env      = ["CODER_AGENT_TOKEN=${coder_agent.main.token}"]
+  restart  = "unless-stopped"
 
   devices {
     host_path = "/dev/nvidia0"

--- a/matlab-cpu/main.tf
+++ b/matlab-cpu/main.tf
@@ -169,6 +169,7 @@ resource "docker_container" "workspace" {
   dns        = ["1.1.1.1"]
   entrypoint = ["sh", "-c", coder_agent.main.init_script]
   env        = ["CODER_AGENT_TOKEN=${coder_agent.main.token}"]
+  restart    = "unless-stopped"
 
   host {
     host = "host.docker.internal"

--- a/matlab-gpu/main.tf
+++ b/matlab-gpu/main.tf
@@ -186,6 +186,7 @@ resource "docker_container" "workspace" {
   dns        = ["1.1.1.1"]
   entrypoint = ["sh", "-c", coder_agent.main.init_script]
   env        = ["CODER_AGENT_TOKEN=${coder_agent.main.token}"]
+  restart    = "unless-stopped"
 
   devices {
     host_path = "/dev/nvidia0"


### PR DESCRIPTION
This ensures that workspaces can auto-reconnect in case of a docker host reboot.